### PR TITLE
fixing broken parsing in `info_post`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 build
 .mypy_cache
 *.egg-info
+env/
+__pycache__*

--- a/tiktok_downloader/scrapper.py
+++ b/tiktok_downloader/scrapper.py
@@ -104,7 +104,7 @@ class info_post:
         if not self.js['props']['pageProps'].get('itemInfo'):
             self.status_code = self.js['props']['pageProps'].get("statusCode")
             self.id = "error_" + str(self.status_code)
-            return
+            raise InvalidUrl("error_" + str(self.status_code))
         if not (
             self.js['props']['pageProps']
             ['itemInfo']['itemStruct'].get('challenges')

--- a/tiktok_downloader/scrapper.py
+++ b/tiktok_downloader/scrapper.py
@@ -102,9 +102,8 @@ class info_post:
         self.full = full
         self.js = js
         if not self.js['props']['pageProps'].get('itemInfo'):
-            self.status_code = self.js['props']['pageProps'].get("statusCode")
-            self.id = "error_" + str(self.status_code)
-            raise InvalidUrl("error_" + str(self.status_code))
+            status_code = self.js['props']['pageProps'].get("statusCode", 0)
+            raise InvalidUrl("error_" + str(status_code))
         if not (
             self.js['props']['pageProps']
             ['itemInfo']['itemStruct'].get('challenges')

--- a/tiktok_downloader/scrapper.py
+++ b/tiktok_downloader/scrapper.py
@@ -101,6 +101,10 @@ class info_post:
     def __init__(self, js: dict, full: dict) -> None:
         self.full = full
         self.js = js
+        if not self.js['props']['pageProps'].get('itemInfo'):
+            self.status_code = self.js['props']['pageProps'].get("statusCode")
+            self.id = "error_" + str(self.status_code)
+            return
         if not (
             self.js['props']['pageProps']
             ['itemInfo']['itemStruct'].get('challenges')
@@ -109,7 +113,7 @@ class info_post:
                 (
                     self.js['props']
                     ['pageProps']['itemInfo']
-                    ['itemStruct']['author']
+                    ['itemStruct']
                 )
             )
         self.video = self.js['props']['pageProps']['itemInfo']['itemStruct']
@@ -159,13 +163,13 @@ class info_post:
 class Account:
 
     def __init__(self, js: dict) -> None:
-        self.avatar = js['avatarThumb']
-        self.username = js['uniqueId']
-        self.nickname = js['nickname']
-        self.signature = js['signature']
-        self.create = datetime.fromtimestamp(int(js['createTime']))
-        self.verified = js['verified']
-        self.private = js["privateAccount"]
+        self.avatar = js.get('avatarThumb')
+        self.username = js.get('uniqueId')
+        self.nickname = js.get('nickname')
+        self.signature = js.get('signature')
+        self.create = datetime.fromtimestamp(int(js.get('createTime', 0)))
+        self.verified = js.get('verified')
+        self.private = js.get("privateAccount")
 
     def __repr__(self) -> str:
         return f"<(OWNER:{self.username} VERIFIED:{self.verified})>"


### PR DESCRIPTION
This PR fixes 2 errors:
* 404 (and other 40*HTTP )errors were returning and index out of range, now they return InvalidUrl to be more aligned with the used exceptions
* in the normal flow, there were cases where the method would break with `TypeError: string indices must be integers` and this was due to a broken parsing, I made it safer to parse in case some data is not present

