### PR TITLE
Fix InvalidUrl exception on correct URLs

### DIFF
--- a/tiktok_downloader/scrapper.py
+++ b/tiktok_downloader/scrapper.py
@@ -26,7 +26,7 @@ class Author:
 class info_post(Session):
     def __init__(self, url: str):
         super().__init__()
-        if 'vt.tiktok.com' in url:
+        if '.tiktok.com' in url:
             url = self.get(
                 url,
                 headers=self.headers,


### PR DESCRIPTION
If a URL is copied from a browser, then it will look like "https://www.tiktok.com/***". In my case, from the app the URL will look like "https://vm.tiktok.com/***". Accordingly, links do not pass this check.