### PR TITLE
Processing URLs from web

### DIFF
--- a/tiktok_downloader/scrapper.py
+++ b/tiktok_downloader/scrapper.py
@@ -26,7 +26,7 @@ class Author:
 class info_post(Session):
     def __init__(self, url: str):
         super().__init__()
-        if '.tiktok.com' in url:
+        if '.tiktok.com' in url and not findall(r'[0-9]{19}', url):
             url = self.get(
                 url,
                 headers=self.headers,


### PR DESCRIPTION
This condition works only for URLs shared via app. For example, this URL from web doesn't process
https://www.tiktok.com/@rizvanov/video/6994155319077195014?is_copy_url=1&is_from_webapp=v1