### PR TITLE
Fix TikWMAsync and tikmate_async 

### DIFF
--- a/tiktok_downloader/tikmate.py
+++ b/tiktok_downloader/tikmate.py
@@ -117,4 +117,4 @@ def tikmate(url: str):
 
 
 async def tikmate_async(url: str):
-    return await tikmateAsync().get_media(url)
+    return await TikmateAsync().get_media(url)

--- a/tiktok_downloader/tiktok_async.py
+++ b/tiktok_downloader/tiktok_async.py
@@ -3,7 +3,7 @@ from .mdown import MdownAsync, mdown_async
 from .snaptik import SnaptikAsync, snaptik_async
 from .ssstik import SsstikAIO, ssstik_async
 from .tikdown import TikdownAsync, tikdown_async
-from .tikmate import tikmateAsync, tikmate_async
+from .tikmate import TikmateAsync, tikmate_async
 from .ttdownloader import TTDownloaderAsync, ttdownloader_async
 
 
@@ -17,7 +17,7 @@ __all__ = [
     'ssstik_async',
     'TikdownAsync',
     'tikdown_async',
-    'tikmateAsync',
+    'TikmateAsync',
     'tikmate_async',
     'TTDownloaderAsync',
     'ttdownloader_async'

--- a/tiktok_downloader/tiktok_async.py
+++ b/tiktok_downloader/tiktok_async.py
@@ -5,6 +5,7 @@ from .ssstik import SsstikAIO, ssstik_async
 from .tikdown import TikdownAsync, tikdown_async
 from .tikmate import TikmateAsync, tikmate_async
 from .ttdownloader import TTDownloaderAsync, ttdownloader_async
+from .tikwm import TikWMAsync, tikwm_async
 
 
 __all__ = [
@@ -20,5 +21,7 @@ __all__ = [
     'TikmateAsync',
     'tikmate_async',
     'TTDownloaderAsync',
-    'ttdownloader_async'
+    'ttdownloader_async',
+    "TikWMAsync",
+    "tikwm_async"
 ]

--- a/tiktok_downloader/tikwm.py
+++ b/tiktok_downloader/tikwm.py
@@ -39,6 +39,7 @@ class TikWM(Session):
 
 class TikWMAsync(AsyncClient):
     BASE_URL = 'https://www.tikwm.com'
+    follow_redirects = True
 
     def __init__(self, url: str) -> None:
         super().__init__()


### PR DESCRIPTION
"Since [version 0.20.0](https://github.com/encode/httpx/releases/tag/0.20.0), httpx no longer follows 3XX redirects in its requests, and instead will raise_for_status() on ANY response that isn't a 2XX." source: https://github.com/mvantellingen/python-zeep/issues/1278